### PR TITLE
chore: add appveyor.yml and simplify lint script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+environment:
+  matrix:
+    - nodejs_version: '6'
+    - nodejs_version: '5'
+    - nodejs_version: '4'
+    - nodejs_version: '3'
+    - nodejs_version: '2'
+    - nodejs_version: '1'
+    - nodejs_version: '0.12'
+    - nodejs_version: '0.10'
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+test_script:
+  - git config --global user.name "Appveyor-CI"
+  - git config --global user.email "dummy@example.org"
+  - node --version
+  - npm --version
+  - npm test

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "shelljs": "^0.6.0"
   },
   "scripts": {
-    "lint": "jshint *.js --exclude node_modules && jscs *.js",
+    "lint": "jshint . --exclude node_modules && jscs .",
     "test": "npm run-script lint && mocha --timeout 30000",
     "coverage": "istanbul cover -x test.js _mocha -- -R spec --timeout 30000 && rm -rf ./coverage"
   },


### PR DESCRIPTION
Added appveyor.yml with all versions of node (since travis.yml has all except the missing v6). Also simplified the lint script to work on windows (don't use unix glob syntax). It still lints all folders (confirmed locally).