### PR TITLE
fix(windows): escape command percent signs on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ function gitRawCommits(options) {
     '"<%- from ? [from, to].join("..") : to %>" '
   )(options) + args.join(' ');
 
+  if (process.platform === 'win32') {
+    // Git format strings have percent signs in them
+    // On windows percent signs need to be doubled to escape them,
+    // so that they aren't used for variable expansion
+    cmd.replace(/%/g, '%%');
+  }
+
   if (options.debug) {
     options.debug('Your git-log command is:\n' + cmd);
   }


### PR DESCRIPTION
This is the most logical place to fix problems with percent signs in git log format strings (e.g.  https://github.com/conventional-changelog/standard-version/issues/59). [If the percent sings are doubled, then they are not used for variable expansion.](http://ss64.com/nt/syntax-esc.html)